### PR TITLE
Sync with numenta/master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     git-core \
     gcc \
     g++ \
-    cmake \
+    cmake3 \
     python \
     python2.7 \
     python2.7-dev \


### PR DESCRIPTION
use cmake3 instead of cmake (#3857)

When trying to build this dockerfile i was getting the below error:

`CMake 3.3 or higher is required. You are running version 2.8.12.2`

Using cmake3 resolves this.