### PR TITLE
Fix: Use print_function for py2 compat.

### DIFF
--- a/tests/integration/nupic/algorithms/tm_likelihood_test.py
+++ b/tests/integration/nupic/algorithms/tm_likelihood_test.py
@@ -45,6 +45,8 @@ Seq1: a-b-b-c-d
 There should be four segments a-b
 """
 
+from __future__ import print_function
+
 import numpy
 import unittest
 

--- a/tests/integration/nupic/algorithms/tm_overlapping_sequences_test.py
+++ b/tests/integration/nupic/algorithms/tm_overlapping_sequences_test.py
@@ -39,6 +39,8 @@ and 10 elements long.
 
 """
 
+from __future__ import print_function
+
 import numpy
 import pprint
 import random

--- a/tests/integration/nupic/algorithms/tm_test.py
+++ b/tests/integration/nupic/algorithms/tm_test.py
@@ -433,6 +433,8 @@ the older sequences?).
 
 """
 
+from __future__ import print_function
+
 import pickle
 import numpy
 import pickle

--- a/tests/integration/nupic/algorithms/tutorial_temporal_memory_test.py
+++ b/tests/integration/nupic/algorithms/tutorial_temporal_memory_test.py
@@ -19,6 +19,8 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+from future.utils import with_metaclass
+
 import nupic.bindings.algorithms
 import pprint
 import unittest
@@ -29,7 +31,7 @@ from nupic.data.generators.pattern_machine import ConsecutivePatternMachine
 from nupic.support.unittesthelpers.abstract_temporal_memory_test import AbstractTemporalMemoryTest
 
 
-class TutorialTemporalMemoryTest(AbstractTemporalMemoryTest, metaclass=ABCMeta):
+class TutorialTemporalMemoryTest(with_metaclass(ABCMeta, AbstractTemporalMemoryTest)):
   VERBOSITY = 1
 
   def getPatternMachine(self):

--- a/tests/regression/run_opf_benchmarks_test.py
+++ b/tests/regression/run_opf_benchmarks_test.py
@@ -26,6 +26,8 @@ prediction metrics. Limiting the number of permutations can cause the test to
 fail if it results in lower accuracy.
 """
 
+from __future__ import print_function
+
 import sys
 import os
 import time

--- a/tests/swarming/nupic/swarming/swarming_test.py
+++ b/tests/swarming/nupic/swarming/swarming_test.py
@@ -19,6 +19,8 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+from __future__ import print_function
+
 import sys
 import os
 import imp


### PR DESCRIPTION
Added more fixes for py2 tests compat.

So far what's left to fix are incorrect usage of the latest nupic.bindings.* modules. For example,

```
tests/unit/nupic/regions/tm_region_test.py:33: in <module>
    from nupic.regions.tm_region import TMRegion
../../../Library/Python/2.7/lib/python/site-packages/nupic-1.0.6.dev0-py2.7.egg/nupic/regions/tm_region.py:32: in <module>
    from nupic.bindings.regions.PyRegion import PyRegion
../../../Library/Python/2.7/lib/python/site-packages/nupic.bindings-1.0.7.dev0-py2.7-macosx-10.14-x86_64.egg/nupic/bindings/__init__.py:73: in <module>
    algorithms = import_helper('nupic.bindings.algorithms')
../../../Library/Python/2.7/lib/python/site-packages/nupic.bindings-1.0.7.dev0-py2.7-macosx-10.14-x86_64.egg/nupic/bindings/__init__.py:44: in import_helper
    fp, pathname, description = imp.find_module(basename, [dirname(__file__)])
E   ImportError: No module named algorithms```

Looks like py2 is not picking up nupic.bindings.* .